### PR TITLE
Harden XeLaTeX conversion for over-escaped Markdown and add Arch dependency support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,3 +25,52 @@ After reinstalling:
 Use this as the default post-fix workflow:
 
 `./scripts/verify-install.sh --install --convert your-file.md`
+
+## Non-interactive conversion (for agents and CI)
+
+`mdtexpdf convert` prompts interactively for title, author, date, and
+footer when no template.tex exists.  To run non-interactively, always
+provide all four flags:
+
+```bash
+./mdtexpdf.sh convert \
+  -t "Document Title" \
+  -a "Author Name" \
+  -d "yes" \
+  --no-footer \
+  input.md
+```
+
+The four interactive prompts and their flags:
+
+| Prompt          | Flag              | Example                       |
+|-----------------|-------------------|-------------------------------|
+| Title           | `-t` / `--title`  | `-t "My Doc"`                |
+| Author          | `-a` / `--author` | `-a "Jane Doe"`              |
+| Date            | `-d` / `--date`   | `-d "yes"` (current date)    |
+| Footer          | `--no-footer`     | `--no-footer` to skip        |
+
+Date flag values: `yes` = current date, `no` = disabled, `YYYY-MM-DD` /
+`DD/MM/YY` / `"Month Day, Year"` = formatted current date, any other
+string = literal date text.  Footer: use `--no-footer` to skip, or
+`-f "text"` to set custom footer text.
+
+If a template.tex already exists in the working directory, these flags
+are not needed — pandoc uses it directly.
+
+## LaTeX-safe code blocks (latex_safe_code.lua)
+
+A Lua filter that prevents the #1 LaTeX build failure: bare `$` inside
+syntax-highlighted code blocks.  When Pandoc applies `--highlight-style=tango`,
+code tokens get wrapped in `\textcolor[rgb]{...}{...}`.  A `$` inside one
+of those tokens enters math mode and breaks LaTeX's brace grouping,
+producing `"Extra }, or forgotten $"` errors.
+
+The filter strips the language tag from fenced code blocks that contain
+`$`, disabling highlighting for that block while preserving monospace
+Verbatim rendering.  It is loaded unconditionally and is a no-op for
+code blocks without problematic characters.
+
+`--force-preprocess` extends this to also strip highlighting from code
+blocks containing `{`, `}`, or `#`.  The flag is communicated to the
+filter via the `MDTEXPDF_FORCE_PREPROCESS` environment variable.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# Agent Notes
+
+## System-vs-Workspace Binary
+This repository may be used on machines that already have a system/user-installed `mdtexpdf` on `PATH` (for example `~/.local/bin/mdtexpdf`).
+
+When fixing bugs in this repo:
+1. Test with the workspace script first to validate local code changes:
+   - `./mdtexpdf.sh ...`
+2. If you test with `mdtexpdf ...`, verify which binary is running:
+   - `command -v mdtexpdf`
+   - `readlink -f "$(command -v mdtexpdf)"`
+3. After a fix is confirmed, reinstall from this repo so the installed copy matches the fix:
+   - `make build`
+4. Prefer the scripted verification flow to avoid terminal drift and PATH confusion:
+   - `./scripts/verify-install.sh --install`
+   - Optional conversion smoke test: `./scripts/verify-install.sh --convert your-file.md`
+
+## Quick sanity check
+After reinstalling:
+- `command -v mdtexpdf`
+- `mdtexpdf --version`
+- Re-run the previously failing conversion command.
+
+## Recommended one-liner
+Use this as the default post-fix workflow:
+
+`./scripts/verify-install.sh --install --convert your-file.md`

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -23,9 +23,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     texlive-fonts-recommended \
     texlive-fonts-extra \
     texlive-science \
+    texlive-lang-chinese \
     texlive-xetex \
     texlive-luatex \
     imagemagick \
+    fonts-lmodern \
     fonts-dejavu \
     fonts-noto-cjk \
     bash \

--- a/PR_DRAFT.md
+++ b/PR_DRAFT.md
@@ -1,0 +1,72 @@
+# PR: Harden XeLaTeX pipeline + Arch Linux dependency docs
+
+## Summary
+This PR improves resilience for real-world Markdown/LaTeX input (especially Google Docs/Gemini-exported docs), fixes several runtime failures in minimal LaTeX environments, and adds explicit Arch Linux dependency guidance.
+
+## Why
+Users hit multiple conversion failures despite having core tooling installed:
+- Missing fonts (`Latin Modern Roman`, `CMU Serif` files)
+- Missing optional LaTeX packages (`xeCJK.sty`, `dutchcal.sty`)
+- Over-escaped math emitted by Google Docs exports (examples: `\\epsilon`, `\\ll`, `\\=`, `\\+`, `\\<`)
+
+The combined result was repeated `fontspec`, `Undefined control sequence`, and `Missing $ inserted` failures during PDF conversion.
+
+## What changed
+### 1) Template hardening (`lib/template.sh`)
+- Added font fallback chains for XeLaTeX/LuaLaTeX:
+  - Main: Latin Modern Roman → TeX Gyre Termes
+  - Sans: Latin Modern Sans → TeX Gyre Heros
+  - Mono: Latin Modern Mono → TeX Gyre Cursor
+- Made `xeCJK` optional via `\IfFileExists{xeCJK.sty}` with warning instead of hard failure.
+- Made CJK font selection conditional via `\IfFontExistsTF`.
+- Replaced hardcoded CMU file-path font setup (`cmunrm` family) with fallback-safe `\newfontfamily` logic.
+- Made `dutchcal` optional via `\IfFileExists{dutchcal.sty}`.
+- Added compatibility shims for escaped angle brackets (`\<`, `\>`).
+
+### 2) Markdown preprocessing normalization (`lib/preprocess.sh`)
+Added sanitation pass for common over-escaping patterns from Google Docs / converted research exports:
+- `\<`, `\>` → `<`, `>`
+- `\\command` → `\command` for math commands
+- `\=`, `\+`, `\_x`, `\^x` → `=`, `+`, `_x`, `^x`
+
+This eliminates common LaTeX parse failures in equations/tables without requiring manual source cleanup.
+
+### 3) Docker base image deps (`Dockerfile.base`)
+Added packages required by hardened template defaults:
+- `fonts-lmodern`
+- `texlive-lang-chinese`
+
+### 4) Documentation updates (Arch Linux)
+Updated install guidance in:
+- `README.md`
+- `examples/multilingual/README.md`
+- `examples/multilingual/multilingual.md`
+
+Included:
+- Arch equivalents for core packages (`pandoc-cli`, `texlive-*`, `noto-fonts-cjk`, `imagemagick`)
+- Optional Arch package for extended LaTeX coverage: `texlive-fontsextra`
+- Troubleshooting entries for missing font/package errors
+
+## Validation
+- Ran shell syntax checks:
+  - `bash -n lib/template.sh`
+  - `bash -n lib/preprocess.sh`
+- Verified successful end-to-end conversion on a previously failing Google Docs/Gemini-generated manuscript (`book.pdf` produced).
+
+## Scope note
+Please exclude local user test content from this PR:
+- `book.md` (local reproduction document)
+
+## Suggested PR title
+Harden XeLaTeX conversion for over-escaped Markdown and add Arch dependency support
+
+## Suggested commit message
+fix: harden LaTeX template/preprocess for minimal TeX envs and Google Docs exports
+
+docs: add Arch Linux dependency mappings and optional texlive extras
+
+## Checklist
+- [x] Backward-compatible behavior in normal documents
+- [x] No hard failure when optional fonts/packages are absent
+- [x] Arch dependency docs updated
+- [x] Docker base updated for required runtime dependencies

--- a/README.md
+++ b/README.md
@@ -113,10 +113,11 @@ mdtexpdf/
 
 - [Pandoc](https://pandoc.org/installing.html) - Markdown to LaTeX conversion
 - LaTeX distribution:
-  - Linux: TexLive (`texlive-latex-base texlive-latex-recommended texlive-latex-extra texlive-science`)
+  - Linux (Debian/Ubuntu): TexLive (`texlive-latex-base texlive-latex-recommended texlive-latex-extra texlive-science`)
+  - Linux (Arch): TexLive (`texlive-basic texlive-latex texlive-latexrecommended texlive-latexextra texlive-fontsrecommended texlive-mathscience texlive-xetex`) + Latin Modern font (`otf-latin-modern`)
   - macOS: MacTeX or BasicTeX
   - Windows: MiKTeX
-- For CJK support: Noto Sans CJK fonts (`fonts-noto-cjk` on Debian/Ubuntu)
+- For CJK support: Noto Sans CJK fonts (`fonts-noto-cjk` on Debian/Ubuntu, `noto-fonts-cjk` on Arch)
 
 ## Installation
 
@@ -140,6 +141,16 @@ mdtexpdf convert book.md --read-metadata --epub
 # Install dependencies (Ubuntu/Debian)
 sudo apt install pandoc texlive-latex-base texlive-latex-recommended \
   texlive-latex-extra texlive-fonts-recommended texlive-science texlive-xetex
+
+# Install dependencies (Arch Linux)
+sudo pacman -S --needed pandoc-cli texlive-basic texlive-latex texlive-latexrecommended \
+  texlive-latexextra texlive-fontsrecommended texlive-mathscience texlive-xetex \
+  texlive-langchinese \
+  otf-latin-modern
+
+# Optional Arch dependencies for extended template features
+# (recommended if you hit missing-package/font errors)
+sudo pacman -S --needed texlive-fontsextra
 
 # Install mdtexpdf
 git clone https://github.com/ucli-tools/mdtexpdf.git
@@ -337,6 +348,7 @@ cover_overlay_opacity: 0.3            # Dark overlay for readability
 Requires ImageMagick (`convert` command). Install with:
 ```bash
 sudo apt install imagemagick    # Debian/Ubuntu
+sudo pacman -S --needed imagemagick  # Arch Linux
 brew install imagemagick        # macOS
 ```
 
@@ -426,7 +438,9 @@ Common issues:
 1. **Missing Pandoc**: Ensure Pandoc is installed and in PATH
 2. **LaTeX errors**: Verify LaTeX distribution is complete
 3. **Long equations**: Use `\\` for manual breaks or `\begin{multline*}...\end{multline*}`
-4. **CJK characters**: Install `fonts-noto-cjk` package
+4. **CJK characters**: Install `fonts-noto-cjk` (Debian/Ubuntu) or `noto-fonts-cjk` (Arch)
+5. **fontspec "Latin Modern Roman" not found**: Install `fonts-lmodern` (Debian/Ubuntu) or `otf-latin-modern` (Arch)
+6. **`dutchcal.sty` not found**: Install `texlive-fontsextra` (Arch) or `texlive-fonts-extra` (Debian/Ubuntu)
 
 ## License
 

--- a/examples/multilingual/README.md
+++ b/examples/multilingual/README.md
@@ -59,15 +59,26 @@ For CJK content, you need:
    ```bash
    # Ubuntu/Debian
    sudo apt-get install fonts-noto-cjk
+
+   # Arch Linux
+   sudo pacman -S --needed noto-fonts-cjk
    ```
 3. **xeCJK package**:
    ```bash
+   # Ubuntu/Debian
    sudo apt-get install texlive-lang-chinese texlive-lang-japanese texlive-lang-korean
+
+   # Arch Linux
+   sudo pacman -S --needed texlive-langchinese texlive-langjapanese texlive-langkorean
    ```
 
 For Arabic/Hebrew:
 ```bash
+# Ubuntu/Debian
 sudo apt-get install texlive-lang-arabic
+
+# Arch Linux
+sudo pacman -S --needed texlive-langarabic
 ```
 
 ## How It Works

--- a/examples/multilingual/multilingual.md
+++ b/examples/multilingual/multilingual.md
@@ -277,11 +277,18 @@ For best results with CJK content:
    ```bash
    # Ubuntu/Debian
    sudo apt-get install fonts-noto-cjk
+
+   # Arch Linux
+   sudo pacman -S --needed noto-fonts-cjk
    ```
 
 2. The xeCJK package must be available:
    ```bash
+   # Ubuntu/Debian
    sudo apt-get install texlive-lang-chinese
+
+   # Arch Linux
+   sudo pacman -S --needed texlive-langchinese
    ```
 
 3. For Arabic/Hebrew (RTL languages), additional configuration may be needed.

--- a/filters/latex_safe_code.lua
+++ b/filters/latex_safe_code.lua
@@ -1,0 +1,74 @@
+-- latex_safe_code.lua
+-- Pandoc Lua filter to prevent LaTeX errors caused by special characters
+-- inside syntax-highlighted code blocks.
+--
+-- Problem:
+--   When Pandoc applies syntax highlighting (e.g. --highlight-style=tango),
+--   it wraps code tokens in \textcolor[rgb]{...}{...}.  A bare $ inside one
+--   of these tokens enters math mode and breaks LaTeX's {/} grouping,
+--   producing "Extra }, or forgotten $" errors.
+--
+--   This is the #1 cause of LaTeX build failures in documents that contain
+--   shell variables ($VAR), SQL ($param), or any code with dollar signs.
+--
+-- Solution (AST-level, not regex):
+--   1. CodeBlock: strip the language class from fenced code blocks that
+--      contain $ — this disables highlighting for that block while
+--      preserving the monospace Verbatim rendering.  The original language
+--      is preserved as a source-language attribute for reference.
+--   2. --force-preprocess: additionally strip highlighting from code blocks
+--      containing { } # characters that can also break inside \textcolor.
+--
+-- Why a Lua filter instead of bash preprocessing?
+--   The Pandoc AST already knows what is code and what is math/prose.
+--   Regex-based approaches in bash must track fenced-block state manually
+--   and cannot distinguish `$var` in code from `$x^2$` in prose.
+--   The DOM exists precisely for this.
+
+local force = os.getenv("MDTEXPDF_FORCE_PREPROCESS") == "1"
+
+---------------------------------------------------------------------------
+-- CodeBlock: strip language tag when content contains characters that
+-- break inside \textcolor{...}{...}
+---------------------------------------------------------------------------
+function CodeBlock(el)
+  -- Only act on blocks that have a language class (i.e. would be highlighted)
+  if #el.classes == 0 then return nil end
+
+  local text = el.text
+  local strip = false
+  local reason = ""
+
+  -- Always strip language tag if the block contains $
+  -- This is the primary fix for "Extra }, or forgotten $" errors
+  if text:match('%$') then
+    strip = true
+    reason = "contains $"
+  end
+
+  -- In force mode, also strip for { } # that can break inside \textcolor
+  if not strip and force then
+    if text:match('[{}]') then
+      strip = true
+      reason = "contains {/} [force-preprocess]"
+    elseif text:match('#') then
+      strip = true
+      reason = "contains # [force-preprocess]"
+    end
+  end
+
+  if strip then
+    local lang = el.classes[1]
+    io.stderr:write("[latex_safe_code] Stripped language tag '"
+      .. lang .. "' from code block (" .. reason .. ")\n")
+    el.classes = {}
+    el.attributes['source-language'] = lang  -- preserve for reference
+    return el
+  end
+
+  return nil
+end
+
+return {
+  { CodeBlock = CodeBlock },
+}

--- a/lib/args.sh
+++ b/lib/args.sh
@@ -40,6 +40,7 @@ init_convert_args() {
     ARG_INDEX=false
     ARG_LULU=false
     ARG_TRIM_SIZE=""
+    ARG_FORCE_PREPROCESS=false
 
     # Reset file variables
     INPUT_FILE=""
@@ -82,6 +83,8 @@ show_convert_usage() {
     echo -e "  --index               Generate index from [index:term] markers"
     echo -e "  --lulu                Generate Lulu.com print-ready output (interior + cover spread)"
     echo -e "  --trim-size SIZE      Set trim size: 5.5x8.5, 6x9, 7x10, a5, a4 (default: from metadata or a4)"
+    echo -e "  --force-preprocess    Aggressively sanitize code blocks for LaTeX (strip highlighting"
+    echo -e "                        from blocks with $, {, }, #). Use when LaTeX fails on code content."
 }
 
 # Parse command-line arguments for convert command
@@ -228,6 +231,10 @@ parse_convert_args() {
             --trim-size)
                 ARG_TRIM_SIZE="$2"
                 shift 2
+                ;;
+            --force-preprocess)
+                ARG_FORCE_PREPROCESS=true
+                shift
                 ;;
             --format)
                 ARG_FORMAT="$2"

--- a/lib/convert.sh
+++ b/lib/convert.sh
@@ -793,6 +793,343 @@ setup_pdf_bibliography() {
 }
 
 # =============================================================================
+# Helper: Pandoc Stderr Diagnostics
+# =============================================================================
+# Parses Pandoc's stderr output (which includes LaTeX error messages) when
+# the actual .log file is not available.  Pandoc captures the LaTeX engine's
+# stderr and re-emits it, so the error patterns are similar but less detailed.
+# Arguments:
+#   $1 - stderr_file: Path to the captured stderr file
+#   $2 - source_md: Path to the original markdown file (for reference)
+# Returns: 0 always (diagnostics are printed, not returned)
+diagnose_pandoc_stderr() {
+    local stderr_file="$1"
+    local source_md="$2"
+
+    if [ ! -f "$stderr_file" ] || [ ! -s "$stderr_file" ]; then
+        echo -e "${YELLOW}No Pandoc error output captured.${NC}"
+        return 0
+    fi
+
+    echo ""
+    echo -e "${RED}═══════════════════════════════════════════════════════════${NC}"
+    echo -e "${RED}  LaTeX Error Diagnostics (from Pandoc output)${NC}"
+    echo -e "${RED}═══════════════════════════════════════════════════════════${NC}"
+
+    # Extract the first few fatal errors (lines starting with "! ")
+    local error_count=0
+    while IFS= read -r error_line; do
+        error_count=$((error_count + 1))
+        if [ "$error_count" -le 5 ]; then
+            echo -e "${RED}  Error $error_count: $error_line${NC}"
+        fi
+    done < <(grep '^! ' "$stderr_file" 2>/dev/null)
+
+    if [ "$error_count" -eq 0 ]; then
+        # Pandoc wraps errors with "Error producing PDF." — show those lines too
+        local pandoc_errors
+        pandoc_errors=$(grep -i 'error' "$stderr_file" 2>/dev/null | head -5)
+        if [ -n "$pandoc_errors" ]; then
+            echo -e "${YELLOW}  Pandoc reported:${NC}"
+            while IFS= read -r pe; do
+                echo -e "${YELLOW}    $pe${NC}"
+            done <<< "$pandoc_errors"
+        else
+            echo -e "${YELLOW}  No explicit errors found in Pandoc output.${NC}"
+        fi
+    elif [ "$error_count" -gt 5 ]; then
+        echo -e "${YELLOW}  ... and $((error_count - 5)) more errors${NC}"
+    fi
+
+    # Extract the context lines (l.XXXX) that show where the error occurred
+    local loc_lines
+    loc_lines=$(grep '^l\.' "$stderr_file" 2>/dev/null | head -5)
+    if [ -n "$loc_lines" ]; then
+        echo ""
+        echo -e "${PURPLE}  Error locations in generated LaTeX:${NC}"
+        while IFS= read -r loc_line; do
+            echo -e "${PURPLE}    $loc_line${NC}"
+        done <<< "$loc_lines"
+    fi
+
+    # Detect common error patterns and provide actionable advice
+    echo ""
+    echo -e "${BLUE}  Common cause analysis:${NC}"
+
+    # Pattern: Extra }, or forgotten $ — typically bare $ in code/highlighted text
+    if grep -q 'Extra }, or forgotten \$' "$stderr_file" 2>/dev/null; then
+        echo -e "${YELLOW}  ⚠ Detected: 'Extra }, or forgotten \$' error${NC}"
+        echo -e "${YELLOW}    This usually means a \$ character appears inside a LaTeX command${NC}"
+        echo -e "${YELLOW}    (e.g., inside \\textcolor from code highlighting or a table cell).${NC}"
+        echo -e "${YELLOW}    Fix: Wrap the content in backticks (\`...\`) for inline code,${NC}"
+        echo -e "${YELLOW}    or use a fenced code block (\`\`\`...\`\`\`) instead of a bare code span.${NC}"
+        echo -e "${YELLOW}    Alternatively, escape the dollar sign in markdown: \\\$ instead of \${NC}"
+    fi
+
+    # Pattern: Missing $ inserted — unescaped math characters in text mode
+    if grep -q 'Missing \$ inserted' "$stderr_file" 2>/dev/null; then
+        echo -e "${YELLOW}  ⚠ Detected: 'Missing \$ inserted' error${NC}"
+        echo -e "${YELLOW}    A math character (like _ or ^) appeared outside math mode,${NC}"
+        echo -e "${YELLOW}    or a \$ in a code block was tokenized by the syntax highlighter.${NC}"
+        echo -e "${YELLOW}    Fix: Use a fenced code block without a language tag (no highlighting),${NC}"
+        echo -e "${YELLOW}    or escape the dollar sign: \\\$ instead of \$ .${NC}"
+    fi
+
+    # Pattern: Undefined control sequence
+    if grep -q 'Undefined control sequence' "$stderr_file" 2>/dev/null; then
+        echo -e "${YELLOW}  ⚠ Detected: Undefined control sequence${NC}"
+        local undef_cmds
+        undef_cmds=$(grep 'Undefined control sequence' "$stderr_file" 2>/dev/null | head -3)
+        while IFS= read -r uc; do
+            echo -e "${YELLOW}      $uc${NC}"
+        done <<< "$undef_cmds"
+        echo -e "${YELLOW}    Fix: Check for misspelled LaTeX commands or missing packages.${NC}"
+    fi
+
+    # Pattern: xdvipdfmx fatal — font/driver issue
+    if grep -q 'xdvipdfmx:fatal' "$stderr_file" 2>/dev/null; then
+        echo -e "${YELLOW}  ⚠ Detected: xdvipdfmx fatal error${NC}"
+        echo -e "${YELLOW}    This is often caused by corrupt or variable-font TTF files.${NC}"
+        echo -e "${YELLOW}    Fix: Remove variable-font files (*[wght].ttf) and rebuild the font cache.${NC}"
+        echo -e "${YELLOW}    Run: fc-cache -fv && luaotfload-tool --update${NC}"
+    fi
+
+    # Pattern: Missing character in font
+    if grep -q 'Missing character' "$stderr_file" 2>/dev/null; then
+        echo -e "${YELLOW}  ⚠ Detected: Missing character(s) in font${NC}"
+        local missing_chars
+        missing_chars=$(grep 'Missing character' "$stderr_file" 2>/dev/null | head -3)
+        while IFS= read -r mc; do
+            echo -e "${YELLOW}      $mc${NC}"
+        done <<< "$missing_chars"
+        echo -e "${YELLOW}    Fix: Check if the font supports these characters, or use \\ensuremath{}${NC}"
+    fi
+
+    echo ""
+    echo -e "${BLUE}  Source markdown: $source_md${NC}"
+    echo -e "${RED}═══════════════════════════════════════════════════════════${NC}"
+    echo ""
+    return 0
+}
+
+# =============================================================================
+# Helper: LaTeX Error Diagnostics (from .log file)
+# =============================================================================
+# Parses the LaTeX .log file after a failed conversion and extracts
+# actionable error information with line context.
+# Arguments:
+#   $1 - log_file: Path to the .log file
+#   $2 - source_md: Path to the original markdown file (for reference)
+# Returns: 0 always (diagnostics are printed, not returned)
+diagnose_latex_error() {
+    local log_file="$1"
+    local source_md="$2"
+
+    if [ ! -f "$log_file" ]; then
+        echo -e "${YELLOW}No LaTeX log file found at $log_file${NC}"
+        return 0
+    fi
+
+    echo ""
+    echo -e "${RED}═══════════════════════════════════════════════════════════${NC}"
+    echo -e "${RED}  LaTeX Error Diagnostics${NC}"
+    echo -e "${RED}═══════════════════════════════════════════════════════════${NC}"
+
+    # Extract the first few fatal errors (lines starting with "! ")
+    local error_count=0
+    while IFS= read -r error_line; do
+        error_count=$((error_count + 1))
+        if [ "$error_count" -le 5 ]; then
+            echo -e "${RED}  Error $error_count: $error_line${NC}"
+        fi
+    done < <(grep '^! ' "$log_file" 2>/dev/null)
+
+    if [ "$error_count" -eq 0 ]; then
+        echo -e "${YELLOW}  No explicit '! ' errors found in log.${NC}"
+        # Check for common non-! error patterns
+        local fatal_line
+        fatal_line=$(grep -m1 -i 'fatal\|Emergency stop\|Fatal error' "$log_file" 2>/dev/null)
+        if [ -n "$fatal_line" ]; then
+            echo -e "${YELLOW}  Found: $fatal_line${NC}"
+        fi
+    elif [ "$error_count" -gt 5 ]; then
+        echo -e "${YELLOW}  ... and $((error_count - 5)) more errors (see log for details)${NC}"
+    fi
+
+    # Extract the context lines (l.XXXX) that show where the error occurred
+    echo ""
+    echo -e "${PURPLE}  Error locations in generated LaTeX:${NC}"
+    local loc_count=0
+    while IFS= read -r loc_line; do
+        loc_count=$((loc_count + 1))
+        if [ "$loc_count" -le 5 ]; then
+            echo -e "${PURPLE}    $loc_line${NC}"
+        fi
+    done < <(grep '^l\.' "$log_file" 2>/dev/null | head -5)
+
+    # Detect common error patterns and provide actionable advice
+    echo ""
+    echo -e "${BLUE}  Common cause analysis:${NC}"
+
+    # Pattern: Extra }, or forgotten $ — typically bare $ in code/highlighted text
+    if grep -q 'Extra }, or forgotten \$' "$log_file" 2>/dev/null; then
+        echo -e "${YELLOW}  ⚠ Detected: 'Extra }, or forgotten \$' error${NC}"
+        echo -e "${YELLOW}    This usually means a \$ character appears inside a LaTeX command${NC}"
+        echo -e "${YELLOW}    (e.g., inside \\textcolor from code highlighting or a table cell).${NC}"
+        echo -e "${YELLOW}    Fix: Wrap the content in backticks (\`...\`) for inline code,${NC}"
+        echo -e "${YELLOW}    or use a fenced code block (\`\`\`...\`\`\`) instead of a bare code span.${NC}"
+        echo -e "${YELLOW}    Alternatively, escape the dollar sign in markdown: \\\$ instead of \${NC}"
+    fi
+
+    # Pattern: Missing character — font doesn't have the glyph
+    if grep -q 'Missing character' "$log_file" 2>/dev/null; then
+        local missing_chars
+        missing_chars=$(grep 'Missing character' "$log_file" 2>/dev/null | head -3)
+        echo -e "${YELLOW}  ⚠ Detected: Missing character(s) in font${NC}"
+        echo -e "${YELLOW}    Some characters could not be rendered:${NC}"
+        while IFS= read -r mc; do
+            echo -e "${YELLOW}      $mc${NC}"
+        done <<< "$missing_chars"
+        echo -e "${YELLOW}    Fix: Check if the font supports these characters, or use \\ensuremath{}${NC}"
+    fi
+
+    # Pattern: Undefined control sequence
+    if grep -q 'Undefined control sequence' "$log_file" 2>/dev/null; then
+        local undef_cmds
+        undef_cmds=$(grep 'Undefined control sequence' "$log_file" 2>/dev/null | head -3)
+        echo -e "${YELLOW}  ⚠ Detected: Undefined control sequence${NC}"
+        echo -e "${YELLOW}    LaTeX encountered an unknown command:${NC}"
+        while IFS= read -r uc; do
+            echo -e "${YELLOW}      $uc${NC}"
+        done <<< "$undef_cmds"
+        echo -e "${YELLOW}    Fix: Check for misspelled LaTeX commands or missing packages.${NC}"
+    fi
+
+    # Pattern: Missing $ inserted — unescaped math characters in text mode
+    if grep -q 'Missing \$ inserted' "$log_file" 2>/dev/null; then
+        echo -e "${YELLOW}  ⚠ Detected: 'Missing \$ inserted' error${NC}"
+        echo -e "${YELLOW}    A math character (like _ or ^) appeared outside math mode.${NC}"
+        echo -e "${YELLOW}    Fix: Escape underscores (\\_), carets (\\^), or wrap in \$...\$ for math.${NC}"
+    fi
+
+    # Pattern: xdvipdfmx fatal — font/driver issue
+    if grep -q 'xdvipdfmx:fatal' "$log_file" 2>/dev/null; then
+        echo -e "${YELLOW}  ⚠ Detected: xdvipdfmx fatal error${NC}"
+        echo -e "${YELLOW}    This is often caused by corrupt or variable-font TTF files.${NC}"
+        echo -e "${YELLOW}    Fix: Remove variable-font files (*[wght].ttf) and rebuild the font cache.${NC}"
+        echo -e "${YELLOW}    Run: fc-cache -fv && luaotfload-tool --update${NC}"
+    fi
+
+    echo ""
+    echo -e "${BLUE}  Full log file: $log_file${NC}"
+    echo -e "${BLUE}  Source markdown: $source_md${NC}"
+    echo -e "${RED}═══════════════════════════════════════════════════════════${NC}"
+    echo ""
+    return 0
+}
+
+# =============================================================================
+# Helper: Markdown Lint for LaTeX Compatibility
+# =============================================================================
+# Checks the markdown source for patterns that commonly break LaTeX output.
+# Reports warnings but does not modify the file.
+# Arguments:
+#   $1 - input_file: Path to markdown file
+# Returns: 0 always (warnings are printed, not returned)
+lint_markdown_for_latex() {
+    local input_file="$1"
+    local total_warnings=0
+
+    # Skip lint if file doesn't exist
+    [ -f "$input_file" ] || return 0
+
+    # Check 1: Bare $ characters in table rows that aren't paired math delimiters
+    # Tables with pipes |...| containing $ that aren't paired $...$ are problematic
+    local table_warning_count=0
+    while IFS= read -r line; do
+        local line_num="${line%%:*}"
+        local content="${line#*:}"
+        table_warning_count=$((table_warning_count + 1))
+        if [ "$table_warning_count" -le 10 ]; then
+            echo -e "${YELLOW}  ⚠ Line $line_num: Table row with unpaired \$ or special chars:${NC}${BLUE} ${content:0:80}${NC}"
+        fi
+    done < <(grep -nP '^\|.*[\$!].*\|' "$input_file" 2>/dev/null | grep -vP '\$[^$]*\$' | head -10)
+
+    if [ "$table_warning_count" -gt 0 ]; then
+        echo -e "${YELLOW}  ($table_warning_count table rows with potentially problematic characters)${NC}"
+        echo -e "${YELLOW}  Hint: Wrap table cells with special chars in backtick code spans (\`...\`)${NC}"
+        total_warnings=$((total_warnings + table_warning_count))
+    fi
+
+    # Check 2: Inline code spans with $ or ! that might break inside \textcolor
+    # This is the most common cause of "Extra }, or forgotten $" errors
+    local code_warning_count=0
+    while IFS= read -r line; do
+        local line_num="${line%%:*}"
+        local content="${line#*:}"
+        code_warning_count=$((code_warning_count + 1))
+        if [ "$code_warning_count" -le 5 ]; then
+            echo -e "${YELLOW}  ⚠ Line $line_num: Inline code contains \$ or ! characters:${NC}${BLUE} ${content:0:80}${NC}"
+        fi
+    done < <(grep -nP '`[^`]*[\$!][^`]*`' "$input_file" 2>/dev/null | head -5)
+
+    if [ "$code_warning_count" -gt 0 ]; then
+        echo -e "${YELLOW}  ($code_warning_count inline code spans with \$ or ! characters)${NC}"
+        echo -e "${YELLOW}  Hint: These may break inside Pandoc's syntax highlighting (\\textcolor).${NC}"
+        echo -e "${YELLOW}  Consider using a fenced code block or escaping \$ as \\\$ .${NC}"
+        total_warnings=$((total_warnings + code_warning_count))
+    fi
+
+    # Check 3: Unpaired $ signs outside of code blocks (potential math mode issues)
+    local unpaired_dollar_count=0
+    local in_code_block=false
+    local md_line_num=0
+    while IFS= read -r line; do
+        md_line_num=$((md_line_num + 1))
+        # Track fenced code blocks
+        local line_start="${line:0:3}"
+        if [[ "$line_start" == "~~~" ]] || [[ "$line_start" == '```' ]]; then
+            if [ "$in_code_block" = true ]; then
+                in_code_block=false
+            else
+                in_code_block=true
+            fi
+            continue
+        fi
+        # Skip lines inside code blocks
+        [ "$in_code_block" = true ] && continue
+
+        # Count dollar signs on this line (excluding escaped \$)
+        local clean_line
+        clean_line=$(echo "$line" | sed 's/\\\$//g')
+        local dollar_count
+        dollar_count=$(echo "$clean_line" | tr -cd '$' | wc -c)
+        # Odd number of $ means unpaired (potential issue)
+        if [ $((dollar_count % 2)) -ne 0 ] && [ "$dollar_count" -gt 0 ]; then
+            unpaired_dollar_count=$((unpaired_dollar_count + 1))
+            if [ "$unpaired_dollar_count" -le 5 ]; then
+                echo -e "${YELLOW}  ⚠ Line $md_line_num: Odd number of \$ signs ($dollar_count) — possible unpaired math delimiter:${NC}${BLUE} ${line:0:80}${NC}"
+            fi
+        fi
+    done < "$input_file"
+
+    if [ "$unpaired_dollar_count" -gt 0 ]; then
+        echo -e "${YELLOW}  ($unpaired_dollar_count lines with unpaired \$ signs)${NC}"
+        echo -e "${YELLOW}  Hint: Ensure every \$ has a matching closing \$, or escape as \\\$ .${NC}"
+        total_warnings=$((total_warnings + unpaired_dollar_count))
+    fi
+
+    # Summary
+    if [ "$total_warnings" -gt 0 ]; then
+        echo ""
+        echo -e "${YELLOW}  Total: $total_warnings lint warning(s) found.${NC}"
+        echo -e "${YELLOW}  These may cause LaTeX errors. Fix them or wrap in code blocks.${NC}"
+    fi
+
+    return 0
+}
+
+# =============================================================================
 # Helper: Execute Pandoc and Cleanup
 # =============================================================================
 # Runs the pandoc command and performs post-conversion cleanup.
@@ -822,6 +1159,14 @@ execute_pandoc() {
         return $?
     fi
 
+    # Locate the LaTeX log file for error diagnostics on failure.
+    # Pandoc runs the engine in a temp dir and cleans it up, so the .log
+    # often disappears before we can read it.  Instead, capture Pandoc's
+    # stderr (which includes the LaTeX error output) into a temp file.
+    local _pdf_log_file=""
+    local _pandoc_stderr_file
+    _pandoc_stderr_file=$(mktemp --suffix=.pandoc.stderr)
+
     if pandoc "$_PDF_PROCESSED_INPUT_FILE" \
         --from markdown \
         --to pdf \
@@ -840,7 +1185,7 @@ execute_pandoc() {
         "${_PDF_HEADER_FOOTER_VARS[@]}" \
         "${_PDF_BOOK_FEATURE_VARS[@]}" \
         "${_PDF_TRIM_VARS[@]}" \
-        --standalone; then
+        --standalone 2>"$_pandoc_stderr_file"; then
         echo -e "${GREEN}Success! PDF created as $OUTPUT_FILE${NC}"
 
         # Additional message for CJK documents
@@ -848,10 +1193,38 @@ execute_pandoc() {
             echo -e "${GREEN}✓ CJK characters (Chinese, Japanese, Korean) have been properly rendered in the PDF.${NC}"
         fi
 
+        # Clean up stderr capture on success
+        rm -f "$_pandoc_stderr_file"
+
         _cleanup_pdf_artifacts
         return 0
     else
         echo -e "${RED}Error: PDF conversion failed.${NC}"
+
+        # Try to find the actual .log file (Pandoc may preserve it in some configs)
+        _pdf_log_file="${OUTPUT_FILE%.pdf}.log"
+        if [ ! -f "$_pdf_log_file" ]; then
+            _pdf_log_file=$(find "$(dirname "$OUTPUT_FILE")" -maxdepth 1 -name "*.log" -newer "$_PDF_TEMPLATE_PATH" 2>/dev/null | head -1)
+        fi
+
+        # Provide LaTeX error diagnostics:
+        # 1) From the actual .log file if available (most detailed)
+        # 2) From Pandoc's stderr capture (always available, less detailed)
+        if [ -f "$_pdf_log_file" ]; then
+            diagnose_latex_error "$_pdf_log_file" "$INPUT_FILE"
+        elif [ -s "$_pandoc_stderr_file" ]; then
+            diagnose_pandoc_stderr "$_pandoc_stderr_file" "$INPUT_FILE"
+        else
+            echo -e "${YELLOW}Could not locate error details for diagnostics.${NC}"
+        fi
+
+        # Clean up stderr capture
+        rm -f "$_pandoc_stderr_file"
+
+        # Run the markdown linter to flag potential source issues
+        echo -e "${BLUE}Running markdown lint for LaTeX compatibility...${NC}"
+        lint_markdown_for_latex "$_PDF_PROCESSED_INPUT_FILE"
+
         _cleanup_pdf_artifacts
         return 1
     fi
@@ -943,6 +1316,17 @@ _execute_pandoc_with_index() {
         return 0
     else
         echo -e "${RED}Error: PDF was not generated.${NC}"
+
+        # Provide LaTeX error diagnostics from the log file
+        local _idx_log_file="${base_name}.log"
+        if [ -f "$_idx_log_file" ]; then
+            diagnose_latex_error "$_idx_log_file" "$INPUT_FILE"
+        fi
+
+        # Run the markdown linter to flag potential source issues
+        echo -e "${BLUE}Running markdown lint for LaTeX compatibility...${NC}"
+        lint_markdown_for_latex "$_PDF_PROCESSED_INPUT_FILE"
+
         rm -f "${base_name}.tex" "${base_name}.aux" "${base_name}.log" \
               "${base_name}.toc" "${base_name}.lof" "${base_name}.lot" \
               "${base_name}.idx" "${base_name}.ind" "${base_name}.ilg" \
@@ -992,6 +1376,12 @@ generate_pdf() {
     preprocess_markdown "$INPUT_FILE"
 
     # Image captions are now handled by the image_size_filter.lua Lua filter
+
+    # Proactive lint: check for markdown patterns that commonly break LaTeX.
+    # This runs before the expensive pandoc invocation so the user gets early
+    # feedback.  (The same linter runs again on failure for context.)
+    echo -e "${BLUE}Checking markdown for LaTeX compatibility...${NC}"
+    lint_markdown_for_latex "$INPUT_FILE"
 
     # Convert markdown to PDF using pandoc with our template
     echo -e "${YELLOW}Converting $INPUT_FILE to PDF...${NC}"

--- a/lib/convert.sh
+++ b/lib/convert.sh
@@ -369,6 +369,10 @@ setup_lua_filters() {
         "wide table sizing" \
         "Wide tables may overflow page margins."
 
+    _add_lua_filter "latex_safe_code.lua" \
+        "LaTeX-safe code blocks" \
+        "Code blocks with $ may cause 'Extra }' LaTeX errors."
+
     # Conditional filters
     if [ "$ARG_FORMAT" = "book" ]; then
         _add_lua_filter "book_structure.lua" \
@@ -1374,6 +1378,16 @@ _cleanup_pdf_artifacts() {
 generate_pdf() {
     # Preprocess the markdown file for better LaTeX compatibility
     preprocess_markdown "$INPUT_FILE"
+
+    # Export force-preprocess flag for the latex_safe_code.lua Lua filter.
+    # The filter reads MDTEXPDF_FORCE_PREPROCESS to decide whether to also
+    # strip highlighting from code blocks containing { } # (in addition to $).
+    if [ "$ARG_FORCE_PREPROCESS" = true ]; then
+        export MDTEXPDF_FORCE_PREPROCESS=1
+        echo -e "${YELLOW}Force-preprocess enabled: aggressive code block sanitization for LaTeX${NC}"
+    else
+        export MDTEXPDF_FORCE_PREPROCESS=0
+    fi
 
     # Image captions are now handled by the image_size_filter.lua Lua filter
 

--- a/lib/convert.sh
+++ b/lib/convert.sh
@@ -805,6 +805,15 @@ setup_pdf_bibliography() {
 execute_pandoc() {
     # shellcheck disable=SC2086 # Word splitting is intentional for _PDF_PANDOC_OPTS/_PDF_FILTER_OPTION/_PDF_TOC_OPTION/_PDF_SECTION_NUMBERING_OPTION
 
+    # The listings package cannot handle multi-byte UTF-8 characters (e.g. ℏ, π)
+    # inside \lstinline under XeLaTeX/LuaLaTeX. Use Pandoc's default fancyvrb
+    # highlighting for Unicode engines; keep --listings for pdfLaTeX.
+    if [ "$PDF_ENGINE" = "xelatex" ] || [ "$PDF_ENGINE" = "lualatex" ]; then
+        _PDF_LISTINGS_OPTION=""
+    else
+        _PDF_LISTINGS_OPTION="--listings"
+    fi
+
     # When --index is used, we need a multi-step build: pandoc→latex, then
     # xelatex + makeindex + xelatex to generate the index with page numbers.
     # Pandoc's --to pdf doesn't run makeindex between LaTeX passes.
@@ -824,7 +833,7 @@ execute_pandoc() {
         "${_PDF_BIBLIOGRAPHY_VARS[@]}" \
         --variable=geometry:margin=1in \
         --highlight-style=tango \
-        --listings \
+        $_PDF_LISTINGS_OPTION \
         $_PDF_TOC_OPTION \
         $_PDF_SECTION_NUMBERING_OPTION \
         "${_PDF_FOOTER_VARS[@]}" \
@@ -874,7 +883,7 @@ _execute_pandoc_with_index() {
         "${_PDF_BIBLIOGRAPHY_VARS[@]}" \
         --variable=geometry:margin=1in \
         --highlight-style=tango \
-        --listings \
+        $_PDF_LISTINGS_OPTION \
         $_PDF_TOC_OPTION \
         $_PDF_SECTION_NUMBERING_OPTION \
         "${_PDF_FOOTER_VARS[@]}" \

--- a/lib/pdf.sh
+++ b/lib/pdf.sh
@@ -57,6 +57,17 @@ detect_unicode_characters() {
         return 0  # Found typographic characters
     fi
 
+    # Check for mathematical Unicode characters that require XeLaTeX/LuaLaTeX
+    # with unicode-math + STIX Two Math for proper rendering.
+    # Mathematical Operators: U+2200-U+22FF (∀∈∞∑∫→←⇒⇔∪∩⊂⊃⊆⊇≠≤≥≈…)
+    # Arrows: U+2190-U+21FF (→←↔⇒⇐⇔⇌)
+    # Superscripts/Subscripts: U+2070-U+209F (⁰⁸⁹⁺⁻₀₁₂)
+    # Letterlike Symbols: U+2100-U+214F (ℝℤℕℚℂℏℓ)
+    # Phonetic Extensions: U+1D00-U+1D7F (ᵍᵐ)
+    if grep -qP '[\x{2070}-\x{209F}\x{2100}-\x{214F}\x{2190}-\x{21FF}\x{2200}-\x{22FF}\x{1D00}-\x{1D7F}]' "$input_file" 2>/dev/null; then
+        return 0  # Found mathematical Unicode characters
+    fi
+
     return 1  # No Unicode characters requiring special handling found
 }
 

--- a/lib/template.sh
+++ b/lib/template.sh
@@ -120,55 +120,108 @@ BOOK_CMDS_EOF
     \\ifluatex
         % LuaLaTeX-specific setup
         \\usepackage{fontspec}
-        % Load fonts with Unicode support
-        \\setmainfont{Latin Modern Roman}[Ligatures=TeX]
-        \\setsansfont{Latin Modern Sans}[Ligatures=TeX]
-        \\setmonofont{Latin Modern Mono}[Ligatures=TeX]
+        % Load fonts with Unicode support (with fallbacks for minimal environments)
+        \\IfFontExistsTF{Latin Modern Roman}{
+            \\setmainfont{Latin Modern Roman}[Ligatures=TeX]
+        }{
+            \\IfFontExistsTF{TeX Gyre Termes}{
+                \\setmainfont{TeX Gyre Termes}[Ligatures=TeX]
+            }{}
+        }
+        \\IfFontExistsTF{Latin Modern Sans}{
+            \\setsansfont{Latin Modern Sans}[Ligatures=TeX]
+        }{
+            \\IfFontExistsTF{TeX Gyre Heros}{
+                \\setsansfont{TeX Gyre Heros}[Ligatures=TeX]
+            }{}
+        }
+        \\IfFontExistsTF{Latin Modern Mono}{
+            \\setmonofont{Latin Modern Mono}[Ligatures=TeX]
+        }{
+            \\IfFontExistsTF{TeX Gyre Cursor}{
+                \\setmonofont{TeX Gyre Cursor}[Ligatures=TeX]
+            }{}
+        }
     \\else
         \\ifxetex
             % XeLaTeX-specific setup
             \\usepackage{fontspec}
-            % Load fonts with Unicode support
-            \\setmainfont{Latin Modern Roman}[Ligatures=TeX]
-            \\setsansfont{Latin Modern Sans}[Ligatures=TeX]
-            \\setmonofont{Latin Modern Mono}[Ligatures=TeX]
+            % Load fonts with Unicode support (with fallbacks for minimal environments)
+            \\IfFontExistsTF{Latin Modern Roman}{
+                \\setmainfont{Latin Modern Roman}[Ligatures=TeX]
+            }{
+                \\IfFontExistsTF{TeX Gyre Termes}{
+                    \\setmainfont{TeX Gyre Termes}[Ligatures=TeX]
+                }{}
+            }
+            \\IfFontExistsTF{Latin Modern Sans}{
+                \\setsansfont{Latin Modern Sans}[Ligatures=TeX]
+            }{
+                \\IfFontExistsTF{TeX Gyre Heros}{
+                    \\setsansfont{TeX Gyre Heros}[Ligatures=TeX]
+                }{}
+            }
+            \\IfFontExistsTF{Latin Modern Mono}{
+                \\setmonofont{Latin Modern Mono}[Ligatures=TeX]
+            }{
+                \\IfFontExistsTF{TeX Gyre Cursor}{
+                    \\setmonofont{TeX Gyre Cursor}[Ligatures=TeX]
+                }{}
+            }
 
             % Additional Unicode font setup for CJK characters (after packages are loaded)
-            % Use xeCJK with minimal punctuation interference to preserve Western quote formatting
-            \\usepackage{xeCJK}
-            \\setCJKmainfont{Noto Sans CJK SC}
-            \\setCJKsansfont{Noto Sans CJK SC}
-            \\setCJKmonofont{Noto Sans Mono CJK SC}
-            % Configure xeCJK to minimize punctuation effects
-            \\xeCJKsetup{
-                AutoFakeBold=false,
-                AutoFakeSlant=false,
-                CheckSingle=false,
-                PunctStyle=plain
+            % Load xeCJK only when available to avoid hard failures in minimal environments
+            \\IfFileExists{xeCJK.sty}{
+                \\usepackage{xeCJK}
+                \\IfFontExistsTF{Noto Sans CJK SC}{
+                    \\setCJKmainfont{Noto Sans CJK SC}
+                    \\setCJKsansfont{Noto Sans CJK SC}
+                }{}
+                \\IfFontExistsTF{Noto Sans Mono CJK SC}{
+                    \\setCJKmonofont{Noto Sans Mono CJK SC}
+                }{}
+                % Configure xeCJK to minimize punctuation effects
+                \\xeCJKsetup{
+                    AutoFakeBold=false,
+                    AutoFakeSlant=false,
+                    CheckSingle=false,
+                    PunctStyle=plain
+                }
+                % Declare Western quotation marks as Default class so xeCJK doesn't process them
+                % This preserves Western quote formatting even when CJK characters are present
+                \\xeCJKDeclareCharClass{Default}{"0022}  % ASCII double quote "
+                \\xeCJKDeclareCharClass{Default}{"0027}  % ASCII single quote '
+                \\xeCJKDeclareCharClass{Default}{"2018}  % Left single quotation mark '
+                \\xeCJKDeclareCharClass{Default}{"2019}  % Right single quotation mark '
+                \\xeCJKDeclareCharClass{Default}{"201C}  % Left double quotation mark "
+                \\xeCJKDeclareCharClass{Default}{"201D}  % Right double quotation mark "
+                \\xeCJKDeclareCharClass{Default}{"2032}  % Prime '
+                \\xeCJKDeclareCharClass{Default}{"2033}  % Double prime ″
+            }{
+                \\PackageWarningNoLine{mdtexpdf}{xeCJK.sty not found; CJK typography enhancements disabled}
             }
-            % Declare Western quotation marks as Default class so xeCJK doesn't process them
-            % This preserves Western quote formatting even when CJK characters are present
-            \\xeCJKDeclareCharClass{Default}{"0022}  % ASCII double quote "
-            \\xeCJKDeclareCharClass{Default}{"0027}  % ASCII single quote '
-            \\xeCJKDeclareCharClass{Default}{"2018}  % Left single quotation mark '
-            \\xeCJKDeclareCharClass{Default}{"2019}  % Right single quotation mark '
-            \\xeCJKDeclareCharClass{Default}{"201C}  % Left double quotation mark "
-            \\xeCJKDeclareCharClass{Default}{"201D}  % Right double quotation mark "
-            \\xeCJKDeclareCharClass{Default}{"2032}  % Prime '
-            \\xeCJKDeclareCharClass{Default}{"2033}  % Double prime ″
 
             % Unicode font switching for Greek, Egyptian, Cuneiform
             \\usepackage{ucharclasses}
-            \\newfontfamily{\\greekfont}{CMU Serif}[
-              Path=/usr/share/texlive/texmf-dist/fonts/opentype/public/cm-unicode/,
-              Extension=.otf,
-              UprightFont=cmunrm,
-              BoldFont=cmunbx,
-              ItalicFont=cmunti,
-              BoldItalicFont=cmunbi
-            ]
-            \\newfontfamily{\\egyptfont}{Noto Sans Egyptian Hieroglyphs}
-            \\newfontfamily{\\cuneifont}{Noto Sans Cuneiform}
+            \\IfFontExistsTF{CMU Serif}{
+                \\newfontfamily{\\greekfont}{CMU Serif}[Ligatures=TeX]
+            }{
+                \\IfFontExistsTF{Latin Modern Roman}{
+                    \\newfontfamily{\\greekfont}{Latin Modern Roman}[Ligatures=TeX]
+                }{
+                    \\newcommand{\\greekfont}{\\rmfamily}
+                }
+            }
+            \\IfFontExistsTF{Noto Sans Egyptian Hieroglyphs}{
+                \\newfontfamily{\\egyptfont}{Noto Sans Egyptian Hieroglyphs}
+            }{
+                \\newcommand{\\egyptfont}{\\rmfamily}
+            }
+            \\IfFontExistsTF{Noto Sans Cuneiform}{
+                \\newfontfamily{\\cuneifont}{Noto Sans Cuneiform}
+            }{
+                \\newcommand{\\cuneifont}{\\rmfamily}
+            }
             \\setTransitionsFor{GreekAndCoptic}{\\greekfont}{\\rmfamily}
             \\setTransitionsFor{EgyptianHieroglyphs}{\\egyptfont}{\\rmfamily}
             \\setTransitionsFor{Cuneiform}{\\cuneifont}{\\rmfamily}
@@ -187,7 +240,12 @@ BOOK_CMDS_EOF
     \\usepackage{mathtools}  % Extends amsmath: paired delimiters, cases*, etc.
     \\usepackage{amssymb}
     \\usepackage{amsthm}   % For theorem and proof environments
-    \\usepackage{dutchcal}  % DCTX Calligraphic: extends \\mathcal to lowercase a-z
+    % Optional: DCTX Calligraphic extends \\mathcal to lowercase a-z
+    \\IfFileExists{dutchcal.sty}{
+        \\usepackage{dutchcal}
+    }{
+        \\PackageWarningNoLine{mdtexpdf}{dutchcal.sty not found; using default \\mathcal behavior}
+    }
     \\usepackage{makeidx}  % For index generation (must load before hyperref)
     \\usepackage{hyperref}
     \\usepackage{xcolor}
@@ -254,6 +312,11 @@ BOOK_CMDS_EOF
 
     % Define \\passthrough command, sometimes used by Pandoc with --listings
     \\providecommand{\\passthrough}[1]{#1}
+
+    % Compatibility shim for escaped angle brackets seen in some math-heavy sources
+    % (e.g., "\\<" and "\\>"). Prefer plain "<" and ">" in math when editing source.
+    \\providecommand{\\<}{\\ifmmode\\mathrel{<}\\else<\\fi}
+    \\providecommand{\\>}{\\ifmmode\\mathrel{>}\\else>\\fi}
 
     % Define common mathematical Unicode characters
     \\ifluatex\\else\\ifxetex\\else

--- a/lib/template.sh
+++ b/lib/template.sh
@@ -121,12 +121,23 @@ BOOK_CMDS_EOF
         % LuaLaTeX-specific setup
         \\usepackage{fontspec}
         % Load fonts with Unicode support (with fallbacks for minimal environments)
-        \\IfFontExistsTF{Latin Modern Roman}{
-            \\setmainfont{Latin Modern Roman}[Ligatures=TeX]
+        % STIX Two Math is preferred as main font: it contains all text glyphs AND full
+        % Unicode math/super/subscript/operator coverage, eliminating "Missing character" warnings.
+        % Note: STIX Two Math only has a Regular weight, so bold/italic are synthesized by fontspec.
+        \\IfFontExistsTF{STIX Two Math}{
+            \\setmainfont{STIX Two Math}[Ligatures=TeX]
         }{
-            \\IfFontExistsTF{TeX Gyre Termes}{
-                \\setmainfont{TeX Gyre Termes}[Ligatures=TeX]
-            }{}
+            \\IfFontExistsTF{STIX Two Text}{
+                \\setmainfont{STIX Two Text}[Ligatures=TeX]
+            }{
+                \\IfFontExistsTF{Latin Modern Roman}{
+                    \\setmainfont{Latin Modern Roman}[Ligatures=TeX]
+                }{
+                    \\IfFontExistsTF{TeX Gyre Termes}{
+                        \\setmainfont{TeX Gyre Termes}[Ligatures=TeX]
+                    }{}
+                }
+            }
         }
         \\IfFontExistsTF{Latin Modern Sans}{
             \\setsansfont{Latin Modern Sans}[Ligatures=TeX]
@@ -142,17 +153,33 @@ BOOK_CMDS_EOF
                 \\setmonofont{TeX Gyre Cursor}[Ligatures=TeX]
             }{}
         }
+        % Math font: STIX Two Math for proper Unicode math glyph coverage
+        \\usepackage{unicode-math}
+        \\IfFontExistsTF{STIX Two Math}{
+            \\setmathfont{STIX Two Math}
+        }{}
     \\else
         \\ifxetex
             % XeLaTeX-specific setup
             \\usepackage{fontspec}
             % Load fonts with Unicode support (with fallbacks for minimal environments)
-            \\IfFontExistsTF{Latin Modern Roman}{
-                \\setmainfont{Latin Modern Roman}[Ligatures=TeX]
+            % STIX Two Math is preferred as main font: it contains all text glyphs AND full
+            % Unicode math/super/subscript/operator coverage, eliminating "Missing character" warnings.
+            % Note: STIX Two Math only has a Regular weight, so bold/italic are synthesized by fontspec.
+            \\IfFontExistsTF{STIX Two Math}{
+                \\setmainfont{STIX Two Math}[Ligatures=TeX]
             }{
-                \\IfFontExistsTF{TeX Gyre Termes}{
-                    \\setmainfont{TeX Gyre Termes}[Ligatures=TeX]
-                }{}
+                \\IfFontExistsTF{STIX Two Text}{
+                    \\setmainfont{STIX Two Text}[Ligatures=TeX]
+                }{
+                    \\IfFontExistsTF{Latin Modern Roman}{
+                        \\setmainfont{Latin Modern Roman}[Ligatures=TeX]
+                    }{
+                        \\IfFontExistsTF{TeX Gyre Termes}{
+                            \\setmainfont{TeX Gyre Termes}[Ligatures=TeX]
+                        }{}
+                    }
+                }
             }
             \\IfFontExistsTF{Latin Modern Sans}{
                 \\setsansfont{Latin Modern Sans}[Ligatures=TeX]
@@ -225,6 +252,12 @@ BOOK_CMDS_EOF
             \\setTransitionsFor{GreekAndCoptic}{\\greekfont}{\\rmfamily}
             \\setTransitionsFor{EgyptianHieroglyphs}{\\egyptfont}{\\rmfamily}
             \\setTransitionsFor{Cuneiform}{\\cuneifont}{\\rmfamily}
+
+            % Math font: STIX Two Math for proper Unicode math glyph coverage
+            \\usepackage{unicode-math}
+            \\IfFontExistsTF{STIX Two Math}{
+                \\setmathfont{STIX Two Math}
+            }{}
         \\else
             % pdfLaTeX-specific setup
             \\usepackage[utf8]{inputenc}
@@ -238,7 +271,10 @@ BOOK_CMDS_EOF
     \\usepackage{graphicx}
     \\usepackage{amsmath}
     \\usepackage{mathtools}  % Extends amsmath: paired delimiters, cases*, etc.
-    \\usepackage{amssymb}
+    \\ifluatex\\else\\ifxetex\\else
+        % amssymb is only needed for pdfLaTeX (unicode-math replaces it under XeLaTeX/LuaLaTeX)
+        \\usepackage{amssymb}
+    \\fi\\fi
     \\usepackage{amsthm}   % For theorem and proof environments
     % Optional: DCTX Calligraphic extends \\mathcal to lowercase a-z
     \\IfFileExists{dutchcal.sty}{

--- a/lib/template.sh
+++ b/lib/template.sh
@@ -121,22 +121,18 @@ BOOK_CMDS_EOF
         % LuaLaTeX-specific setup
         \\usepackage{fontspec}
         % Load fonts with Unicode support (with fallbacks for minimal environments)
-        % STIX Two Math is preferred as main font: it contains all text glyphs AND full
-        % Unicode math/super/subscript/operator coverage, eliminating "Missing character" warnings.
-        % Note: STIX Two Math only has a Regular weight, so bold/italic are synthesized by fontspec.
-        \\IfFontExistsTF{STIX Two Math}{
-            \\setmainfont{STIX Two Math}[Ligatures=TeX]
+        % STIX Two Text is preferred as main font: it has Regular + Bold + Italic + BoldItalic
+        % for proper bold/italic rendering. Math operators not in STIX Two Text are handled
+        % by unicode-math (\setmathfont{STIX Two Math}) and \newunicodechar mappings below.
+        \\IfFontExistsTF{STIX Two Text}{
+            \\setmainfont{STIX Two Text}[Ligatures=TeX]
         }{
-            \\IfFontExistsTF{STIX Two Text}{
-                \\setmainfont{STIX Two Text}[Ligatures=TeX]
+            \\IfFontExistsTF{Latin Modern Roman}{
+                \\setmainfont{Latin Modern Roman}[Ligatures=TeX]
             }{
-                \\IfFontExistsTF{Latin Modern Roman}{
-                    \\setmainfont{Latin Modern Roman}[Ligatures=TeX]
-                }{
-                    \\IfFontExistsTF{TeX Gyre Termes}{
-                        \\setmainfont{TeX Gyre Termes}[Ligatures=TeX]
-                    }{}
-                }
+                \\IfFontExistsTF{TeX Gyre Termes}{
+                    \\setmainfont{TeX Gyre Termes}[Ligatures=TeX]
+                }{}
             }
         }
         \\IfFontExistsTF{Latin Modern Sans}{
@@ -146,12 +142,16 @@ BOOK_CMDS_EOF
                 \\setsansfont{TeX Gyre Heros}[Ligatures=TeX]
             }{}
         }
-        \\IfFontExistsTF{Latin Modern Mono}{
-            \\setmonofont{Latin Modern Mono}[Ligatures=TeX]
+        \\IfFontExistsTF{DejaVu Sans Mono}{
+            \\setmonofont{DejaVu Sans Mono}[Ligatures=TeX]
         }{
-            \\IfFontExistsTF{TeX Gyre Cursor}{
-                \\setmonofont{TeX Gyre Cursor}[Ligatures=TeX]
-            }{}
+            \\IfFontExistsTF{Latin Modern Mono}{
+                \\setmonofont{Latin Modern Mono}[Ligatures=TeX]
+            }{
+                \\IfFontExistsTF{TeX Gyre Cursor}{
+                    \\setmonofont{TeX Gyre Cursor}[Ligatures=TeX]
+                }{}
+            }
         }
         % Math font: STIX Two Math for proper Unicode math glyph coverage
         \\usepackage{unicode-math}
@@ -163,22 +163,18 @@ BOOK_CMDS_EOF
             % XeLaTeX-specific setup
             \\usepackage{fontspec}
             % Load fonts with Unicode support (with fallbacks for minimal environments)
-            % STIX Two Math is preferred as main font: it contains all text glyphs AND full
-            % Unicode math/super/subscript/operator coverage, eliminating "Missing character" warnings.
-            % Note: STIX Two Math only has a Regular weight, so bold/italic are synthesized by fontspec.
-            \\IfFontExistsTF{STIX Two Math}{
-                \\setmainfont{STIX Two Math}[Ligatures=TeX]
+            % STIX Two Text is preferred as main font: it has Regular + Bold + Italic + BoldItalic
+            % for proper bold/italic rendering. Math operators not in STIX Two Text are handled
+            % by unicode-math (\setmathfont{STIX Two Math}) and \newunicodechar mappings below.
+            \\IfFontExistsTF{STIX Two Text}{
+                \\setmainfont{STIX Two Text}[Ligatures=TeX]
             }{
-                \\IfFontExistsTF{STIX Two Text}{
-                    \\setmainfont{STIX Two Text}[Ligatures=TeX]
+                \\IfFontExistsTF{Latin Modern Roman}{
+                    \\setmainfont{Latin Modern Roman}[Ligatures=TeX]
                 }{
-                    \\IfFontExistsTF{Latin Modern Roman}{
-                        \\setmainfont{Latin Modern Roman}[Ligatures=TeX]
-                    }{
-                        \\IfFontExistsTF{TeX Gyre Termes}{
-                            \\setmainfont{TeX Gyre Termes}[Ligatures=TeX]
-                        }{}
-                    }
+                    \\IfFontExistsTF{TeX Gyre Termes}{
+                        \\setmainfont{TeX Gyre Termes}[Ligatures=TeX]
+                    }{}
                 }
             }
             \\IfFontExistsTF{Latin Modern Sans}{
@@ -188,12 +184,16 @@ BOOK_CMDS_EOF
                     \\setsansfont{TeX Gyre Heros}[Ligatures=TeX]
                 }{}
             }
-            \\IfFontExistsTF{Latin Modern Mono}{
-                \\setmonofont{Latin Modern Mono}[Ligatures=TeX]
+            \\IfFontExistsTF{DejaVu Sans Mono}{
+                \\setmonofont{DejaVu Sans Mono}[Ligatures=TeX]
             }{
-                \\IfFontExistsTF{TeX Gyre Cursor}{
-                    \\setmonofont{TeX Gyre Cursor}[Ligatures=TeX]
-                }{}
+                \\IfFontExistsTF{Latin Modern Mono}{
+                    \\setmonofont{Latin Modern Mono}[Ligatures=TeX]
+                }{
+                    \\IfFontExistsTF{TeX Gyre Cursor}{
+                        \\setmonofont{TeX Gyre Cursor}[Ligatures=TeX]
+                    }{}
+                }
             }
 
             % Additional Unicode font setup for CJK characters (after packages are loaded)
@@ -252,6 +252,26 @@ BOOK_CMDS_EOF
             \\setTransitionsFor{GreekAndCoptic}{\\greekfont}{\\rmfamily}
             \\setTransitionsFor{EgyptianHieroglyphs}{\\egyptfont}{\\rmfamily}
             \\setTransitionsFor{Cuneiform}{\\cuneifont}{\\rmfamily}
+
+            % STIX Two Math as fallback font for math Unicode blocks.
+            % STIX Two Text lacks math operators, arrows, double-struck letters, etc.
+            % ucharclasses auto-switches to STIX Two Math when these blocks are encountered.
+            \\IfFontExistsTF{STIX Two Math}{
+                \\newfontfamily{\\mathfallbackfont}{STIX Two Math}[Ligatures=TeX]
+                \\setTransitionsFor{MathematicalOperators}{\\mathfallbackfont}{\\rmfamily}
+                \\setTransitionsFor{SupplementalMathematicalOperators}{\\mathfallbackfont}{\\rmfamily}
+                \\setTransitionsFor{MiscellaneousMathematicalSymbolsA}{\\mathfallbackfont}{\\rmfamily}
+                \\setTransitionsFor{MiscellaneousMathematicalSymbolsB}{\\mathfallbackfont}{\\rmfamily}
+                \\setTransitionsFor{MathematicalAlphanumericSymbols}{\\mathfallbackfont}{\\rmfamily}
+                \\setTransitionsFor{LetterlikeSymbols}{\\mathfallbackfont}{\\rmfamily}
+                \\setTransitionsFor{Arrows}{\\mathfallbackfont}{\\rmfamily}
+                \\setTransitionsFor{SupplementalArrowsA}{\\mathfallbackfont}{\\rmfamily}
+                \\setTransitionsFor{SupplementalArrowsB}{\\mathfallbackfont}{\\rmfamily}
+                \\setTransitionsFor{MiscellaneousTechnical}{\\mathfallbackfont}{\\rmfamily}
+                \\setTransitionsFor{GeometricShapes}{\\mathfallbackfont}{\\rmfamily}
+                \\setTransitionsFor{BoxDrawing}{\\mathfallbackfont}{\\rmfamily}
+                \\setTransitionsFor{SuperscriptsAndSubscripts}{\\mathfallbackfont}{\\rmfamily}
+            }{}
 
             % Math font: STIX Two Math for proper Unicode math glyph coverage
             \\usepackage{unicode-math}
@@ -562,7 +582,61 @@ BOOK_CMDS_EOF
         \\newunicodechar{⁻}{\\ensuremath{^-}}
     \\fi\\fi
 
-    % Configure listings for code blocks
+    % XeLaTeX: ucharclasses already handles font switching for math Unicode blocks
+    % (see \setTransitionsFor above). No additional \newunicodechar needed for operators.
+    % LuaLaTeX: add text-mode math operator mappings via \ensuremath (no ucharclasses support)
+    \\ifluatex
+        \\newunicodechar{→}{\\ensuremath{\\rightarrow}}
+        \\newunicodechar{←}{\\ensuremath{\\leftarrow}}
+        \\newunicodechar{↔}{\\ensuremath{\\leftrightarrow}}
+        \\newunicodechar{⇒}{\\ensuremath{\\Rightarrow}}
+        \\newunicodechar{⇐}{\\ensuremath{\\Leftarrow}}
+        \\newunicodechar{⇔}{\\ensuremath{\\Leftrightarrow}}
+        \\newunicodechar{⇌}{\\ensuremath{\\rightleftharpoons}}
+        \\newunicodechar{∀}{\\ensuremath{\\forall}}
+        \\newunicodechar{∃}{\\ensuremath{\\exists}}
+        \\newunicodechar{∈}{\\ensuremath{\\in}}
+        \\newunicodechar{∉}{\\ensuremath{\\notin}}
+        \\newunicodechar{∋}{\\ensuremath{\\ni}}
+        \\newunicodechar{⊂}{\\ensuremath{\\subset}}
+        \\newunicodechar{⊃}{\\ensuremath{\\supset}}
+        \\newunicodechar{⊆}{\\ensuremath{\\subseteq}}
+        \\newunicodechar{⊇}{\\ensuremath{\\supseteq}}
+        \\newunicodechar{∪}{\\ensuremath{\\cup}}
+        \\newunicodechar{∩}{\\ensuremath{\\cap}}
+        \\newunicodechar{∧}{\\ensuremath{\\wedge}}
+        \\newunicodechar{∨}{\\ensuremath{\\vee}}
+        \\newunicodechar{∞}{\\ensuremath{\\infty}}
+        \\newunicodechar{≠}{\\ensuremath{\\neq}}
+        \\newunicodechar{≤}{\\ensuremath{\\leq}}
+        \\newunicodechar{≥}{\\ensuremath{\\geq}}
+        \\newunicodechar{≈}{\\ensuremath{\\approx}}
+        \\newunicodechar{≡}{\\ensuremath{\\equiv}}
+        \\newunicodechar{∼}{\\ensuremath{\\sim}}
+        \\newunicodechar{∝}{\\ensuremath{\\propto}}
+        \\newunicodechar{∂}{\\ensuremath{\\partial}}
+        \\newunicodechar{∇}{\\ensuremath{\\nabla}}
+        \\newunicodechar{∫}{\\ensuremath{\\int}}
+        \\newunicodechar{∑}{\\ensuremath{\\sum}}
+        \\newunicodechar{∏}{\\ensuremath{\\prod}}
+        \\newunicodechar{√}{\\ensuremath{\\sqrt}}
+        \\newunicodechar{⊗}{\\ensuremath{\\otimes}}
+        \\newunicodechar{◁}{\\ensuremath{\\triangleleft}}
+        \\newunicodechar{ℝ}{\\ensuremath{\\mathbb{R}}}
+        \\newunicodechar{ℤ}{\\ensuremath{\\mathbb{Z}}}
+        \\newunicodechar{ℕ}{\\ensuremath{\\mathbb{N}}}
+        \\newunicodechar{ℚ}{\\ensuremath{\\mathbb{Q}}}
+        \\newunicodechar{ℂ}{\\ensuremath{\\mathbb{C}}}
+    \\fi
+
+    % Phonetic Extensions — modifier letters not in STIX Two Math/Text
+    % These are used in scientific notation (e.g. nuclear isomers: ᵐTc, ᵍ-ray)
+    % Rendered as scaled-down italic text letters as a typographic fallback
+    \\newunicodechar{ᵍ}{{\\fontsize{0.7em}{0.7em}\\selectfont\\textit{g}}}
+    \\newunicodechar{ᵐ}{{\\fontsize{0.7em}{0.7em}\\selectfont\\textit{m}}}
+    % ℏ (U+210F PLANCK CONSTANT OVER TWO PI) — present in STIX Two Text but
+    % mapped to \ensuremath{\hbar} for consistent rendering via the math font
+    \\newunicodechar{ℏ}{\\ensuremath{\\hbar}}
     \\lstset{
       basicstyle=\\ttfamily\\small,
       breaklines=true,          % Enable automatic line breaking

--- a/mdtexpdf.sh
+++ b/mdtexpdf.sh
@@ -352,6 +352,7 @@ install() {
     _install_filter "long_equation_filter.lua" "long equations"
     _install_filter "image_size_filter.lua" "image sizing"
     _install_filter "table_size_filter.lua" "wide tables"
+    _install_filter "latex_safe_code.lua" "LaTeX-safe code blocks"
     _install_filter "book_structure.lua" "book format" "."
     _install_filter "drop_caps_filter.lua" "drop caps" "."
     _install_filter "index_filter.lua" "subject index"
@@ -458,6 +459,7 @@ help() {
     echo -e "                    ${BLUE}--epub-css FILE       Use custom CSS for EPUB${NC}"
     echo -e "                    ${BLUE}-i, --include FILE    Include additional markdown file (repeatable)${NC}"
     echo -e "                    ${BLUE}--index               Generate index from [index:term] markers${NC}"
+    echo -e "                    ${BLUE}--force-preprocess    Aggressively sanitize code for LaTeX${NC}"
     echo -e "                  ${BLUE}Example:${NC} mdtexpdf convert document.md"
     echo -e "                  ${BLUE}Example:${NC} mdtexpdf convert -a \"John Doe\" -t \"My Document\" --toc --toc-depth 3 document.md output.pdf\n"
 

--- a/scripts/verify-install.sh
+++ b/scripts/verify-install.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+DO_INSTALL=false
+CONVERT_FILE=""
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/verify-install.sh [--install] [--convert <file.md>]
+
+Checks:
+  1) Which mdtexpdf binary is on PATH
+  2) Resolved binary path
+  3) mdtexpdf --version
+  4) Workspace vs installed script sync (mdtexpdf.sh)
+  5) Workspace vs installed module sync (preprocess.sh, template.sh)
+
+Options:
+  --install            Run built-in install first (equivalent to: make build)
+  --convert <file.md>  Run a conversion smoke test with default prompt answers
+  -h, --help           Show this help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --install)
+      DO_INSTALL=true
+      shift
+      ;;
+    --convert)
+      [[ $# -ge 2 ]] || { echo "error: --convert requires a file path" >&2; exit 2; }
+      CONVERT_FILE="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown option: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+pass() { echo "✓ $*"; }
+warn() { echo "! $*"; }
+info() { echo "- $*"; }
+
+if $DO_INSTALL; then
+  info "Installing current workspace build via built-in target (make build)..."
+  make build
+  pass "Install completed"
+fi
+
+info "Checking active mdtexpdf on PATH..."
+if ! command -v mdtexpdf >/dev/null 2>&1; then
+  echo "error: mdtexpdf not found on PATH" >&2
+  exit 1
+fi
+
+BIN_PATH="$(command -v mdtexpdf)"
+BIN_REAL="$(readlink -f "$BIN_PATH")"
+
+pass "PATH binary: $BIN_PATH"
+pass "Resolved binary: $BIN_REAL"
+
+info "Version info..."
+mdtexpdf --version
+
+EXPECTED_USER_BIN="$HOME/.local/bin/mdtexpdf"
+if [[ "$BIN_REAL" == "$EXPECTED_USER_BIN" ]]; then
+  pass "Active binary is user-local install ($EXPECTED_USER_BIN)"
+else
+  warn "Active binary is not ~/.local/bin/mdtexpdf (verify this is intended)"
+fi
+
+INST_LIB_DIR="$HOME/.local/share/mdtexpdf/lib"
+if [[ ! -d "$INST_LIB_DIR" ]]; then
+  warn "Installed lib directory not found: $INST_LIB_DIR"
+else
+  pass "Installed lib directory present: $INST_LIB_DIR"
+fi
+
+info "Checking workspace vs installed script/library sync..."
+if cmp -s "$ROOT_DIR/mdtexpdf.sh" "$BIN_REAL"; then
+  pass "mdtexpdf.sh matches installed PATH binary"
+else
+  warn "mdtexpdf.sh differs from installed PATH binary"
+fi
+
+if [[ -f "$INST_LIB_DIR/preprocess.sh" ]]; then
+  if cmp -s "$ROOT_DIR/lib/preprocess.sh" "$INST_LIB_DIR/preprocess.sh"; then
+    pass "lib/preprocess.sh matches installed copy"
+  else
+    warn "lib/preprocess.sh differs from installed copy"
+  fi
+fi
+
+if [[ -f "$INST_LIB_DIR/template.sh" ]]; then
+  if cmp -s "$ROOT_DIR/lib/template.sh" "$INST_LIB_DIR/template.sh"; then
+    pass "lib/template.sh matches installed copy"
+  else
+    warn "lib/template.sh differs from installed copy"
+  fi
+fi
+
+if [[ -n "$CONVERT_FILE" ]]; then
+  if [[ ! -f "$CONVERT_FILE" ]]; then
+    echo "error: convert file not found: $CONVERT_FILE" >&2
+    exit 1
+  fi
+
+  info "Running conversion smoke test with installed binary: $CONVERT_FILE"
+  LOG_FILE="/tmp/mdtexpdf_verify_convert.log"
+  printf '\n\n\n\n\n\n\n\n\n\n' | mdtexpdf convert "$CONVERT_FILE" >"$LOG_FILE" 2>&1 || true
+
+  if grep -q "Success! PDF created as" "$LOG_FILE"; then
+    pass "Conversion smoke test succeeded"
+  else
+    warn "Conversion smoke test did not report success"
+    warn "See log: $LOG_FILE"
+    tail -n 40 "$LOG_FILE" || true
+  fi
+fi
+
+pass "Verification script completed"

--- a/tests/fixtures/test_latex_error_diagnostics.md
+++ b/tests/fixtures/test_latex_error_diagnostics.md
@@ -1,0 +1,30 @@
+---
+title: "Test LaTeX Error Diagnostics"
+author: "mdtexpdf test"
+date: "2025-01-01"
+---
+
+# Error Diagnostics Test
+
+This document contains patterns that commonly break LaTeX output.
+
+## Table with bare $ and ! characters
+
+| Field | Value |
+|-------|-------|
+| query | $event_id \| !room_id \| server_name" |
+| status | $active |
+
+## Inline code with special characters
+
+The variable `$foo!bar` is problematic.
+
+So is `event_id | !room_id`.
+
+## Unpaired dollar signs
+
+This line has an unpaired $ sign which will break math mode.
+
+## Normal content
+
+This paragraph is fine and should not trigger any warnings.

--- a/tests/fixtures/test_unicode_fonts.md
+++ b/tests/fixtures/test_unicode_fonts.md
@@ -1,0 +1,49 @@
+---
+title: "Unicode Font Coverage Test"
+author: "Test Author"
+date: "June 2025"
+---
+
+# Bold, Italic, and Math Symbols
+
+Regular text. **Bold text.** *Italic text.* ***Bold italic.***
+
+## Math Operators
+
+∀, ∃, ∈, ∉, ∋, ⊂, ⊃, ⊆, ⊇, ∪, ∩, ∧, ∨
+
+## Arrows
+
+→, ←, ↔, ⇒, ⇐, ⇔, ⇌
+
+## Relations
+
+≠, ≤, ≥, ≈, ≡, ∼, ∝
+
+## Calculus
+
+∞, ∂, ∇, ∫, ∑, ∏, √
+
+## Letterlike Symbols
+
+ℝ, ℤ, ℕ, ℚ, ℂ, ℏ
+
+## Double-Struck (Math Alphanumeric)
+
+𝕆, 𝕊
+
+## Circled Operators and Shapes
+
+⊗, ◁
+
+## Superscripts and Subscripts
+
+x⁸, H₂O
+
+## Bold Context
+
+**Bold with operators: ∀, ∈, →, ∞, ⊗, ◁, 𝕆, 𝕊**
+
+## Phonetic Extensions
+
+ᵐTc-99, ᵍ-ray


### PR DESCRIPTION
# PR: Harden XeLaTeX pipeline + Arch Linux dependency docs

## Summary
This PR improves resilience for real-world Markdown/LaTeX input (especially Google Docs/Gemini-exported docs), fixes several runtime failures in minimal LaTeX environments, and adds explicit Arch Linux dependency guidance.

## Why
Users hit multiple conversion failures despite having core tooling installed:
- Missing fonts (`Latin Modern Roman`, `CMU Serif` files)
- Missing optional LaTeX packages (`xeCJK.sty`, `dutchcal.sty`)
- Over-escaped math emitted by Google Docs exports (examples: `\\epsilon`, `\\ll`, `\\=`, `\\+`, `\\<`)

The combined result was repeated `fontspec`, `Undefined control sequence`, and `Missing $ inserted` failures during PDF conversion.

## What changed
### 1) Template hardening (`lib/template.sh`)
- Added font fallback chains for XeLaTeX/LuaLaTeX:
  - Main: Latin Modern Roman → TeX Gyre Termes
  - Sans: Latin Modern Sans → TeX Gyre Heros
  - Mono: Latin Modern Mono → TeX Gyre Cursor
- Made `xeCJK` optional via `\IfFileExists{xeCJK.sty}` with warning instead of hard failure.
- Made CJK font selection conditional via `\IfFontExistsTF`.
- Replaced hardcoded CMU file-path font setup (`cmunrm` family) with fallback-safe `\newfontfamily` logic.
- Made `dutchcal` optional via `\IfFileExists{dutchcal.sty}`.
- Added compatibility shims for escaped angle brackets (`\<`, `\>`).

### 2) Markdown preprocessing normalization (`lib/preprocess.sh`)
Added sanitation pass for common over-escaping patterns from Google Docs / converted research exports:
- `\<`, `\>` → `<`, `>`
- `\\command` → `\command` for math commands
- `\=`, `\+`, `\_x`, `\^x` → `=`, `+`, `_x`, `^x`

This eliminates common LaTeX parse failures in equations/tables without requiring manual source cleanup.

### 3) Docker base image deps (`Dockerfile.base`)
Added packages required by hardened template defaults:
- `fonts-lmodern`
- `texlive-lang-chinese`

### 4) Documentation updates (Arch Linux)
Updated install guidance in:
- `README.md`
- `examples/multilingual/README.md`
- `examples/multilingual/multilingual.md`

Included:
- Arch equivalents for core packages (`pandoc-cli`, `texlive-*`, `noto-fonts-cjk`, `imagemagick`)
- Optional Arch package for extended LaTeX coverage: `texlive-fontsextra`
- Troubleshooting entries for missing font/package errors

## Validation
- Ran shell syntax checks:
  - `bash -n lib/template.sh`
  - `bash -n lib/preprocess.sh`
- Verified successful end-to-end conversion on a previously failing Google Docs/Gemini-generated manuscript (`book.pdf` produced).

## Scope note
Please exclude local user test content from this PR:
- `book.md` (local reproduction document)

## Suggested PR title
Harden XeLaTeX conversion for over-escaped Markdown and add Arch dependency support

## Suggested commit message
fix: harden LaTeX template/preprocess for minimal TeX envs and Google Docs exports

docs: add Arch Linux dependency mappings and optional texlive extras

## Checklist
- [x] Backward-compatible behavior in normal documents
- [x] No hard failure when optional fonts/packages are absent
- [x] Arch dependency docs updated
- [x] Docker base updated for required runtime dependencies
